### PR TITLE
Useful Queries

### DIFF
--- a/src/lib/crc2/collections/core/collection.rell
+++ b/src/lib/crc2/collections/core/collection.rell
@@ -30,8 +30,8 @@ function get_tokens_by_collection(collection) {
     return collection_token @* { collection } ( .token );
 }
 
-function get_tokens_by_collection_name(collection_name: text) {
-    return collection_token @* { get_collection_by_name(collection_name) } ( .token );
+query get_tokens_by_collection_name(collection_name: text, take: integer = 500, skip : integer = 500) {
+    return collection_token @* { get_collection_by_name(collection_name) } ( .token ) limit 500 offset skip;
 }
 
 function get_account_balances_by_collection(collection, account: ft4.accounts.account) {

--- a/src/lib/crc2/collections/core/collection.rell
+++ b/src/lib/crc2/collections/core/collection.rell
@@ -38,3 +38,6 @@ function get_account_balances_by_collection(collection, account: ft4.accounts.ac
     val tokens = get_tokens_by_collection(collection);
    return balance @* { account, .token in tokens } ( token = .token, amount = .amount );
 }
+function is_token_in_collection(token, collection) : boolean {
+    return collection_token @? { token, collection } != null;
+}

--- a/src/lib/crc2/collections/core/collection.rell
+++ b/src/lib/crc2/collections/core/collection.rell
@@ -29,11 +29,17 @@ function add_token_to_collection(collection: collection, token) {
 function get_tokens_by_collection(collection) {
     return collection_token @* { collection } ( .token );
 }
-
-function get_tokens_by_collection_name(collection_name: text, take: integer = 500, skip : integer = 500) {
-    return collection_token @* { get_collection_by_name(collection_name) } ( .token ) limit 500 offset skip;
+function _get_tokens_by_collection_name_paginated(collection_name: text, page_size: integer?, page_cursor: text?): list<ft4.utils.pagination_result> {
+    val before_rowid = ft4.utils.before_rowid(page_cursor);
+    return collection_token @* { get_collection_by_name(collection_name) } (
+        ft4.utils.pagination_result(
+            data = (
+                token = .token,
+            ).to_gtv_pretty(),
+            rowid = .rowid
+        )
+    ) limit ft4.utils.fetch_data_size(page_size);
 }
-
 function get_account_balances_by_collection(collection, account: ft4.accounts.account) {
     val tokens = get_tokens_by_collection(collection);
    return balance @* { account, .token in tokens } ( token = .token, amount = .amount );

--- a/src/lib/crc2/collections/core/collection.rell
+++ b/src/lib/crc2/collections/core/collection.rell
@@ -30,7 +30,7 @@ function get_tokens_by_collection(collection) {
     return collection_token @* { collection } ( .token );
 }
 
-query get_tokens_by_collection_name(collection_name: text, take: integer = 500, skip : integer = 500) {
+function get_tokens_by_collection_name(collection_name: text, take: integer = 500, skip : integer = 500) {
     return collection_token @* { get_collection_by_name(collection_name) } ( .token ) limit 500 offset skip;
 }
 

--- a/src/lib/crc2/collections/queries.rell
+++ b/src/lib/crc2/collections/queries.rell
@@ -1,0 +1,6 @@
+query get_tokens_by_collection_name(collection_name: text, page_size: integer?, page_cursor: text?) {
+    return ft4.utils.make_page(
+            _get_tokens_by_collection_name_paginated(collection_name, page_size, page_cursor),
+            page_size
+    );
+}

--- a/src/lib/crc2/token_types/core/module.rell
+++ b/src/lib/crc2/token_types/core/module.rell
@@ -1,1 +1,2 @@
+module;
 import ^^.tokens.core.*;

--- a/src/lib/crc2/token_types/core/token_types.rell
+++ b/src/lib/crc2/token_types/core/token_types.rell
@@ -13,3 +13,6 @@ function is_type(token, type: name){
 function get_token_types(token) : list<name> {
     return token_type @* { token } (.name);
 }
+function get_tokens_with_types(types: list<name>){
+    return token_type @* {.name in types} (.token);
+}

--- a/src/lib/crc2/tokens/core/token.rell
+++ b/src/lib/crc2/tokens/core/token.rell
@@ -10,5 +10,8 @@ function create_token(id: byte_array, protocol_id: integer = CRC2_PROTOCOL_ID) {
 }
 
 function get_token(id: byte_array, origin_brid: byte_array = chain_context.blockchain_rid) {
-    return require(token @? { origin_brid, id }, "Token with id %s not found".format(id));
+    return require(get_token_if_exists(id, origin_brid));
+}
+function get_token_if_exists(id: byte_array, origin_brid: byte_array = chain_context.blockchain_rid) : token? {
+    return token @? { origin_brid, id };
 }

--- a/src/lib/crc2/tokens/core/token.rell
+++ b/src/lib/crc2/tokens/core/token.rell
@@ -10,7 +10,7 @@ function create_token(id: byte_array, protocol_id: integer = CRC2_PROTOCOL_ID) {
 }
 
 function get_token(id: byte_array, origin_brid: byte_array = chain_context.blockchain_rid) {
-    return require(get_token_if_exists(id, origin_brid));
+    return require(get_token_if_exists(id, origin_brid), "Token with id %s not found".format(id));
 }
 function get_token_if_exists(id: byte_array, origin_brid: byte_array = chain_context.blockchain_rid) : token? {
     return token @? { origin_brid, id };


### PR DESCRIPTION
`get_tokens_by_collection_name` -> This is a very useful function for the client-side, so I added optional pagination so our dApp queries can provide the paginated output to the client. I'm sure all clients will benefit from the pagination since a collection can easily become very large

`is_token_in_collection` -> Implementing project doesn't really need to query the `collection_token` entity, in almost all cases we'd like to just confirm if a token is contained within a specific collection.

Usage:

```
function switch_collections(token_id, collection_name){
  val token = crc2.tokens.get_token(token_id);
  val collection_name = crc2.collections.get_collection_by_name(collection_name);
  require(not crc2.collections.is_token_in_collection(token, collection_name), "Token %s is already in collection %s", token_id, collection_name);
}
```
`get_token_if_exists` -> Alot of times, we don't want the library to force a require and halt the operation. We want logic to see if a token exists or not, and handle the fallback gracefully. Currently, we'd have to directly query the entity of the library.

`get_tokens_with_types` -> Get all tokens with a specific type(s) for the `token_type` module

